### PR TITLE
MessageBuilder acts more like a builder.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yadwh"
 license = "MIT"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Yet Another Discord Webhook Crate"
 readme = "README.md"

--- a/examples/create_message.rs
+++ b/examples/create_message.rs
@@ -10,17 +10,18 @@
 //! where:
 //!     Webhook ID: 00001111
 //!     Token:      aaaabbbb
+
 use std::{env, process};
 use yadwh::message::MessageBuilder;
-use yadwh::webhook::WebhookAPI;
+use yadwh::webhook::WebhookApi;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), yadwh::WebhookError> {
     // Verify enough arguments were passed.
     let args: Vec<String> = env::args().collect();
     if args.len() < 3 {
-        println!("error:  not enough arguments supplied.");
-        println!("usage:  create_message [webhook_id] [token]");
+        println!("error: not enough arguments supplied.");
+        println!("usage: create_message [webhook_id] [token]");
         process::exit(-1);
     }
 
@@ -29,36 +30,29 @@ async fn main() {
     let token: String = args[2].to_string();
 
     // Message to be sent.
-    let mut message = MessageBuilder::new();
-
-    // Override the username. Ignoring error check for exceeding length.
-    message.username("Webhook Example").ok();
-
-    // Set the content, check to make sure the length is within limits.
-    match message.content("Content portion of the message.") {
-        Ok(_) => (),
-        Err(error) => println!("{}", error),
-    };
-
-    // Create an embed for the message.
-    message.embed(|embed| {
-        embed
-            .color("#cba6f7")
-            .author("Author Here", None, None, None)
-            .title("Title Here")
-            .description("Description Here\n```rust\nprintln!(\"Hello World!\");```")
-            .field("Field1", "Value1", None)
-            .field("Inline Field1", "Value1", Some(true))
-            .field("Inline Field2", "Value2", Some(true))
-            .field("Inline Field3", "Value3", Some(true))
-            .footer("Footer Here", None, None)
-    });
+    let message = MessageBuilder::new()
+        .username("Webhook Example")?
+        .content("Content portion of the message.")?
+        .embed(|embed| {
+            embed
+                .color("#cba6f7")
+                .author("Author Here", None, None, None)
+                .title("Title Here")
+                .description("Description Here\n```rust\nprintln!(\"Hello World!\");```")
+                .field("Field1", "Value1", None)
+                .field("Inline Field1", "Value1", Some(true))
+                .field("Inline Field2", "Value2", Some(true))
+                .field("Inline Field3", "Value3", Some(true))
+                .footer("Footer Here", None, None)
+        });
 
     // Create the message.
     println!("Creating message.");
-    let webhook = WebhookAPI::new(&webhook_id, &token);
+    let webhook = WebhookApi::new(&webhook_id, &token);
     match webhook.message.create(&message, None).await {
         Ok(resp) => println!("\nMessage created:\n{:#?}", resp),
         Err(error) => println!("Error while creating: {}", error),
     }
+
+    Ok(())
 }

--- a/examples/create_thread_message.rs
+++ b/examples/create_thread_message.rs
@@ -11,12 +11,13 @@
 //!     Webhook ID: 00001111
 //!     Token:      aaaabbbb
 //!     Thread ID:  22223333
+
 use std::{env, process};
 use yadwh::message::MessageBuilder;
-use yadwh::webhook::WebhookAPI;
+use yadwh::webhook::WebhookApi;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), yadwh::WebhookError> {
     // Verify enough arguments were passed.
     let args: Vec<String> = env::args().collect();
     if args.len() < 4 {
@@ -31,36 +32,29 @@ async fn main() {
     let thread_id: String = args[3].to_string();
 
     // Message to be sent.
-    let mut message = MessageBuilder::new();
-
-    // Override the username. Ignoring error check for exceeding length.
-    message.username("Webhook Example").ok();
-
-    // Set the content, check to make sure the length is within limits.
-    match message.content("Content portion of the message.") {
-        Ok(_) => (),
-        Err(error) => println!("{}", error),
-    };
-
-    // Create an embed for the message.
-    message.embed(|embed| {
-        embed
-            .color("#cba6f7")
-            .author("Author Here", None, None, None)
-            .title("Title Here")
-            .description("Description Here\n```rust\nprintln!(\"Hello World!\");```")
-            .field("Field1", "Value1", None)
-            .field("Inline Field1", "Value1", Some(true))
-            .field("Inline Field2", "Value2", Some(true))
-            .field("Inline Field3", "Value3", Some(true))
-            .footer("Footer Here", None, None)
-    });
+    let message = MessageBuilder::new()
+        .username("Webhook Example")?
+        .content("Content portion of the message.")?
+        .embed(|embed| {
+            embed
+                .color("#cba6f7")
+                .author("Author Here", None, None, None)
+                .title("Title Here")
+                .description("Description Here\n```rust\nprintln!(\"Hello World!\");```")
+                .field("Field1", "Value1", None)
+                .field("Inline Field1", "Value1", Some(true))
+                .field("Inline Field2", "Value2", Some(true))
+                .field("Inline Field3", "Value3", Some(true))
+                .footer("Footer Here", None, None)
+        });
 
     // Create the message.
     println!("Creating message.");
-    let webhook = WebhookAPI::new(&webhook_id, &token);
+    let webhook = WebhookApi::new(&webhook_id, &token);
     match webhook.message.create(&message, Some(&thread_id)).await {
         Ok(resp) => println!("\nMessage created:\n{:#?}", resp),
         Err(error) => println!("Error while creating: {}", error),
     }
+
+    Ok(())
 }

--- a/examples/delete_message.rs
+++ b/examples/delete_message.rs
@@ -11,8 +11,9 @@
 //!     Webhook ID: 00001111
 //!     Token:      aaaabbbb
 //!     Message ID: 22223333
+
 use std::{env, process};
-use yadwh::webhook::WebhookAPI;
+use yadwh::webhook::WebhookApi;
 
 #[tokio::main]
 async fn main() {
@@ -31,7 +32,7 @@ async fn main() {
 
     // Delete the message.
     println!("Deleting message {}.", message_id);
-    let webhook = WebhookAPI::new(&webhook_id, &token);
+    let webhook = WebhookApi::new(&webhook_id, &token);
     match webhook.message.delete(&message_id).await {
         Ok(_) => println!("Deleted message {}", message_id),
         Err(error) => println!("Error while deleting: {}", error),

--- a/examples/delete_webhook.rs
+++ b/examples/delete_webhook.rs
@@ -10,8 +10,9 @@
 //! where:
 //!     Webhook ID: 00001111
 //!     Token:      aaaabbbb
+
 use std::{env, process};
-use yadwh::webhook::WebhookAPI;
+use yadwh::webhook::WebhookApi;
 
 #[tokio::main]
 async fn main() {
@@ -29,7 +30,7 @@ async fn main() {
 
     // Delete the webhook.
     println!("Deleting webhook {}.", webhook_id);
-    let webhook = WebhookAPI::new(&webhook_id, &token);
+    let webhook = WebhookApi::new(&webhook_id, &token);
     match webhook.delete().await {
         Ok(_) => println!("Deleted webhook {}.", webhook_id),
         Err(error) => println!("Error while deleting: {}", error),

--- a/examples/edit_message.rs
+++ b/examples/edit_message.rs
@@ -11,12 +11,13 @@
 //!     Webhook ID: 00001111
 //!     Token:      aaaabbbb
 //!     Message ID: 22223333
+
 use std::{env, process};
 use yadwh::message::MessageBuilder;
-use yadwh::webhook::WebhookAPI;
+use yadwh::webhook::WebhookApi;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), yadwh::WebhookError> {
     // Verify enough arguments were passed.
     let args: Vec<String> = env::args().collect();
     if args.len() < 4 {
@@ -32,7 +33,7 @@ async fn main() {
 
     // Get the original message.
     println!("Obtaining message {}.", message_id);
-    let webhook = WebhookAPI::new(&webhook_id, &token);
+    let webhook = WebhookApi::new(&webhook_id, &token);
     let message = match webhook.message.get(&message_id).await {
         Ok(resp) => {
             println!("Message obtained.");
@@ -45,37 +46,29 @@ async fn main() {
     };
 
     // Create a builder from the message to make changes.
-    let mut builder = MessageBuilder::from(&message);
-
-    // Override the username. Ignoring error check for exceeding length.
-    builder.username("Webhook Example").ok();
-
-    // Set the content, check to make sure the length is within limits.
-    match builder.content("New content portion of the message.") {
-        Ok(_) => (),
-        Err(error) => println!("{}", error),
-    };
-
-    // Create an embed for the message.
-    builder.embeds = vec![];
-    builder.embed(|embed| {
-        embed
-            .color("#cba6f7")
-            .author("Author Changed Here", None, None, None)
-            .title("Title Changed Here")
-            .description("Description Changed Here\n```rust\nprintln!(\"Hello World!\");```")
-            .field("Field1 Changed", "Value1", None)
-            .field("Inline Field1", "Changed Value1", Some(true))
-            .field("Inline Field2", "Value2", Some(true))
-            .field("Inline Field3", "Value3", Some(true))
-            .footer("Footer Here", None, None)
-    });
+    let message = MessageBuilder::from(&message)?
+        .username("Webhook Example")?
+        .content("New content portion of the message.")?
+        .embed(|embed| {
+            embed
+                .color("#cba6f7")
+                .author("Author Changed Here", None, None, None)
+                .title("Title Changed Here")
+                .description("Description Changed Here\n```rust\nprintln!(\"Hello World!\");```")
+                .field("Field1 Changed", "Value1", None)
+                .field("Inline Field1", "Changed Value1", Some(true))
+                .field("Inline Field2", "Value2", Some(true))
+                .field("Inline Field3", "Value3", Some(true))
+                .footer("Footer Here", None, None)
+        });
 
     // Edit the message.
     println!("Editing message {}.", message_id);
-    let webhook = WebhookAPI::new(&webhook_id, &token);
-    match webhook.message.edit(&message_id, &builder).await {
+    let webhook = WebhookApi::new(&webhook_id, &token);
+    match webhook.message.edit(&message_id, &message).await {
         Ok(resp) => println!("\nMessage edited:\n{:#?}", resp),
         Err(error) => println!("Error while editing: {}", error),
     }
+
+    Ok(())
 }

--- a/examples/get_message.rs
+++ b/examples/get_message.rs
@@ -11,8 +11,9 @@
 //!     Webhook ID: 00001111
 //!     Token:      aaaabbbb
 //!     Message ID: 22223333
+
 use std::{env, process};
-use yadwh::webhook::WebhookAPI;
+use yadwh::webhook::WebhookApi;
 
 #[tokio::main]
 async fn main() {
@@ -31,7 +32,7 @@ async fn main() {
 
     // Get the message.
     println!("Obtaining message {}.", message_id);
-    let webhook = WebhookAPI::new(&webhook_id, &token);
+    let webhook = WebhookApi::new(&webhook_id, &token);
     match webhook.message.get(&message_id).await {
         Ok(resp) => println!("\nMessage obtained:\n{:#?}", resp),
         Err(error) => println!("Error while obtaining: {}", error),

--- a/examples/get_webhook.rs
+++ b/examples/get_webhook.rs
@@ -10,8 +10,9 @@
 //! where:
 //!     Webhook ID: 00001111
 //!     Token:      aaaabbbb
+
 use std::{env, process};
-use yadwh::webhook::WebhookAPI;
+use yadwh::webhook::WebhookApi;
 
 #[tokio::main]
 async fn main() {
@@ -29,7 +30,7 @@ async fn main() {
 
     // Get the webhook.
     println!("Obtaining webhook {}.", webhook_id);
-    let webhook = WebhookAPI::new(&webhook_id, &token);
+    let webhook = WebhookApi::new(&webhook_id, &token);
     match webhook.get().await {
         Ok(resp) => println!("\nWebhook obtained:\n{:#?}", resp),
         Err(error) => println!("Error while obtaining: {}", error),

--- a/examples/modify_webhook.rs
+++ b/examples/modify_webhook.rs
@@ -10,8 +10,9 @@
 //! where:
 //!     Webhook ID: 00001111
 //!     Token:      aaaabbbb
+
 use std::{env, process};
-use yadwh::webhook::WebhookAPI;
+use yadwh::webhook::WebhookApi;
 
 #[tokio::main]
 async fn main() {
@@ -29,7 +30,7 @@ async fn main() {
 
     // Get the webhook.
     println!("Obtaining webhook {}.", webhook_id);
-    let webhook = WebhookAPI::new(&webhook_id, &token);
+    let webhook = WebhookApi::new(&webhook_id, &token);
     let mut old = match webhook.get().await {
         Ok(resp) => {
             println!("Webhook obtained.");

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,6 +16,7 @@ pub(crate) const ROOT_URI: &str = "https://discord.com/api/v10/webhooks";
 pub type Result<T> = std::result::Result<T, WebhookError>;
 
 /// Enum for handling the expected errors for processing webhook messages.
+#[derive(Debug)]
 pub enum WebhookError {
     /// Non-200 status obtained from the API.
     BadStatus(String),
@@ -23,7 +24,7 @@ pub enum WebhookError {
     NoContent,
     /// Unknown error, details provided.
     Unknown(String),
-    /// Unable to parse an object received from the API.
+    /// Unable to parse an object.
     BadParse(String),
     /// Content or Embed character count is too large.
     TooBig(String, usize, usize),
@@ -93,9 +94,9 @@ impl Limit {
 #[derive(Debug, Clone)]
 pub(crate) struct Client {
     /// ID of the Webhook.
-    pub id: String,
+    pub(crate) id: String,
     /// Token for the Webhook.
-    pub token: String,
+    pub(crate) token: String,
     /// HTTP client used to send requests to the API.
     client: HyperClient<HttpsConnector<HttpConnector>>,
 }
@@ -107,7 +108,7 @@ impl Client {
     ///
     /// * `webhook_id` - ID of the Webhook.
     /// * `webhook_token` - Token of the Webhook.
-    pub fn new(webhook_id: &str, webhook_token: &str) -> Self {
+    pub(crate) fn new(webhook_id: &str, webhook_token: &str) -> Self {
         let connector = HttpsConnector::new();
         Self {
             id: webhook_id.to_string(),
@@ -129,7 +130,7 @@ impl Client {
     /// Method::DELETE, and Method::PATCH.
     /// * `endpoint` - Target endpoint to access.
     /// * `body` - HTTP Body to send to the API (used for POST and PATCH.)
-    pub async fn send(&self, method: Method, endpoint: &str, body: Body) -> Result<String> {
+    pub(crate) async fn send(&self, method: Method, endpoint: &str, body: Body) -> Result<String> {
         let url = format!("{}{}", self.url(), endpoint);
 
         // Build the request for the Method.
@@ -166,7 +167,7 @@ impl Client {
                 StatusCode::NO_CONTENT => Err(WebhookError::NoContent),
                 _ => {
                     let code = format!("Status Code: {}", value.status().as_u16());
-                    Err(WebhookError::BadStatus(format!("{}", code)))
+                    Err(WebhookError::BadStatus(code.to_string()))
                 }
             },
 

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -280,7 +280,7 @@ impl Embed {
         };
 
         // Convert the HEX color to u32.
-        let color_u32: u32 = match u32::from_str_radix(&color_hex, 16) {
+        let color_u32: u32 = match u32::from_str_radix(color_hex, 16) {
             Ok(value) => value,
             Err(_) => return self,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,4 @@ pub mod message;
 pub mod webhook;
 
 pub use crate::client::{Limit, Result, WebhookError};
-pub use crate::webhook::WebhookAPI;
+pub use crate::webhook::WebhookApi;

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -1,10 +1,10 @@
-//! WebhookAPI Client for interacting directly with the Discord API.
+//! WebhookApi Client for interacting directly with the Discord API.
 //!
 //! `webhook` bundles up the required authentication parameters and creates a HTTP client that is
 //! used to interact with the Discord API. All authentication for each request is handled for the user.
 
 use crate::client::{Client, Result, WebhookError};
-use crate::message::MessageAPI;
+use crate::message::MessageApi;
 use hyper::{Body, Method};
 use serde::{Deserialize, Serialize};
 
@@ -33,7 +33,7 @@ pub struct Webhook {
     pub url: String,
 }
 
-/// WebhookAPI is a client that is responsible for making requests to the Discord API.
+/// WebhookApi is a client that is responsible for making requests to the Discord API.
 /// Requires a webhook ID and Token. You can find these requirements in the URL provided for the
 /// webhook.
 ///
@@ -42,14 +42,14 @@ pub struct Webhook {
 /// URL Supplied: https://discord.com/api/webhooks/__111122223333__/**AAAABBBBCCCC**
 /// * Webhook ID: __111122223333__
 /// * Webhook Token: **AAAABBBBCCCC**
-pub struct WebhookAPI {
+pub struct WebhookApi {
     /// HTTP client used to send requests to the API.
     client: Client,
     /// HTTP client used to send requests to the API.
-    pub message: MessageAPI,
+    pub message: MessageApi,
 }
 
-impl WebhookAPI {
+impl WebhookApi {
     /// Creates a new webhook client used to send requests.
     ///
     /// # Arguments
@@ -58,8 +58,29 @@ impl WebhookAPI {
     /// * `webhook_token` - Token of the webhook.
     pub fn new(webhook_id: &str, webhook_token: &str) -> Self {
         let client: Client = Client::new(webhook_id, webhook_token);
-        let message: MessageAPI = MessageAPI::new(&client);
+        let message: MessageApi = MessageApi::new(&client);
         Self { client, message }
+    }
+
+    /// Parses a Discord webhook URL and creates a new `WebhookApi` client.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The full URL of the webhook.
+    ///
+    /// # Returns
+    ///
+    /// A `WebhookApi` instance if the URL is valid, otherwise returns an error.
+    pub fn from_url(url: &str) -> Result<Self> {
+        let parts: Vec<&str> = url.split('/').collect();
+        if parts.len() < 7 {
+            return Err(WebhookError::BadParse("webhook url".to_string()));
+        }
+
+        let webhook_id = parts[parts.len() - 2];
+        let webhook_token = parts[parts.len() - 1];
+
+        Ok(Self::new(webhook_id, webhook_token))
     }
 
     /// Obtains an existing webhook. This will error if it no longer exists.


### PR DESCRIPTION
Rename of API to adhere to Rust naming guidelines.